### PR TITLE
compile Verification Code on macOS.

### DIFF
--- a/draft-bctb-6man-rfc6296-bis.md
+++ b/draft-bctb-6man-rfc6296-bis.md
@@ -1195,6 +1195,7 @@ are said to be "behind" the NPTv6 Translator.
    * POSSIBILITY OF SUCH DAMAGE.
    */
   #include "stdio.h"
+  #include "stdlib.h"
   #include "assert.h"
   /*
    * program to verify the NPTv6 algorithm


### PR DESCRIPTION
Verification Code in appendix B does not compile on the latest version of macOS / Xcode due to an undeclared function erorr.  We should include <stdlib.h> to call atoi(3).

```
% cc --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: x86_64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

% cc nptv6.c
nptv6.c:68:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
add1(number1, number2)
^
nptv6.c:93:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
sub1(number1, number2)
^
nptv6.c:104:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
sum1(numbers, count)
^
nptv6.c:135:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
nptv6_initialization(subnet)
^
nptv6.c:205:1: warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
main(argc, argv)
^
int
nptv6.c:216:19: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
       suppress = atoi(argv[1]);
                  ^
nptv6.c:205:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
main(argc, argv)
^
6 warnings and 1 error generated.
```

fixed:

```
% cc nptv6.c
nptv6.c:69:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
add1(number1, number2)
^
nptv6.c:94:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
sub1(number1, number2)
^
nptv6.c:105:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
sum1(numbers, count)
^
nptv6.c:136:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
nptv6_initialization(subnet)
^
nptv6.c:206:1: warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
main(argc, argv)
^
int
nptv6.c:206:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
6 warnings generated.

% ./a.out 1
outer->inner different: calculated: fd01:203:405:0:2:3:4:5 inner: fd01:203:405:ffff:2:3:4:5
% ./a.out 0
outer->inner different: calculated: fd01:203:405:ffff:2:3:4:5 inner: fd01:203:405:0:2:3:4:5
```